### PR TITLE
skip check_audio_files if not a submodule of klingon-assistant

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,6 +69,8 @@ task checkAudioFiles(type: Exec) {
     commandLine './check_audio_files.pl'
 }
 
+checkAudioFiles.onlyIf { file("../../scripts/check_audio_files.pl").exists() }
+
 preBuild.dependsOn 'updateDatabase'
 preBuild.dependsOn 'checkAudioFiles'
 


### PR DESCRIPTION
Fixes issue #42.