### PR TITLE
Fix Portuguese (Brazil) language code.

### DIFF
--- a/app/src/main/java/org/tlhInganHol/android/klingonassistant/Preferences.java
+++ b/app/src/main/java/org/tlhInganHol/android/klingonassistant/Preferences.java
@@ -93,6 +93,7 @@ public class Preferences extends AppCompatPreferenceActivity
       // system locale is any topolect of Chinese.
       return "zh-HK";
     } else if (language == new Locale("pt").getLanguage()) {
+      // Note: The locale code "pt" is Brazilian Portuguese. (European Portuguese is "pt-PT".)
       return "pt";
     }
     return "NONE";

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -168,7 +168,7 @@
     <string name="secondary_language_russian">Russisch (beta)</string>
     <string name="secondary_language_swedish">Schwedisch (beta)</string>
     <string name="secondary_language_chinese_hong_kong">Hong Kong Chinesisch (beta)</string>
-    <string name="secondary_language_portuguese_brazil">Brasilianisches Portugiesisch (beta)</string>
+    <string name="secondary_language_portuguese">Portugiesisch (beta)</string>
 
     <!-- Metadata labels and descriptions. -->
     <string name="label_see_alt_entry">Siehe</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -157,7 +157,7 @@
     <string name="secondary_language_russian">Russo (beta)</string>
     <string name="secondary_language_swedish">Sueco (beta)</string>
     <string name="secondary_language_chinese_hong_kong">Chines de Hong Kong (beta)</string>
-    <string name="secondary_language_portuguese_brazil">Portugues do Brasil (beta)</string>
+    <string name="secondary_language_portuguese">Português (beta)</string>
 
     <!-- Metadata labels and descriptions. -->
     <string name="label_see_alt_entry">Veja</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -39,7 +39,7 @@
     <item>@string/secondary_language_russian</item>
     <item>@string/secondary_language_swedish</item>
     <item>@string/secondary_language_chinese_hong_kong</item>
-    <item>@string/secondary_language_portuguese_brazil</item>
+    <item>@string/secondary_language_portuguese</item>
   </string-array>
 
   <string-array name="secondaryLanguageChoicesValues">
@@ -49,6 +49,6 @@
     <item>ru</item>
     <item>sv</item>
     <item>zh-HK</item>
-    <item>pt-BR</item>
+    <item>pt</item>
   </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,7 +186,7 @@
     <string name="secondary_language_russian">Russian (beta)</string>
     <string name="secondary_language_swedish">Swedish (beta)</string>
     <string name="secondary_language_chinese_hong_kong">Hong Kong Chinese (beta)</string>
-    <string name="secondary_language_portuguese_brazil">Brazilian Portuguese (beta)</string>
+    <string name="secondary_language_portuguese">Portuguese (beta)</string>
 
     <!-- Metadata labels and descriptions. -->
     <string name="label_see_alt_entry">See</string>


### PR DESCRIPTION
Note: "pt" is equivalent to "pt-BR", i.e., Portuguese (Brazil). European Portuguese is "pt-PT".