### PR TITLE
Fix a bug where singular forms of inherently plural words were not being ignored for the purposes of displaying plural suffix information.

### DIFF
--- a/app/src/main/java/org/tlhInganHol/android/klingonassistant/EntryFragment.java
+++ b/app/src/main/java/org/tlhInganHol/android/klingonassistant/EntryFragment.java
@@ -229,7 +229,7 @@ public class EntryFragment extends Fragment {
     }
 
     // Display plural information.
-    if (!entry.isPlural() && !entry.isInherentPlural() && !entry.isPlural()) {
+    if (!entry.isPlural() && !entry.isInherentPlural() && !entry.isSingularFormOfInherentPlural()) {
       if (entry.isBeingCapableOfLanguage()) {
         expandedDefinition += "\n\n" + resources.getString(R.string.info_being);
       } else if (entry.isBodyPart()) {


### PR DESCRIPTION
This is needed before words like {mang:n} and {negh:n} can be tagged as "being", as requested in https://github.com/De7vID/klingon-assistant-data/issues/478.