### PR TITLE
Add the ability to suppress the display of notes in a non-English language.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 CHANGELOG
 
+2021-10-05: Add ability to suppress display of notes in non-English language.
 2021-09-27: Target to API 30 and fix TTS query permission. Fix the "xifan hol" q to Q search bug.
 2021-08-09: New vocabulary from qep'a' 2021. Allow user-triggered database update over metered Internet.
 2021-04-13: Fix issue where attributes were not displayed in entry title if {pIqaD} is enabled.

--- a/app/src/main/java/org/tlhInganHol/android/klingonassistant/EntryFragment.java
+++ b/app/src/main/java/org/tlhInganHol/android/klingonassistant/EntryFragment.java
@@ -171,9 +171,20 @@ public class EntryFragment extends Fragment {
     if (entry.shouldDisplayOtherLanguageNotes()) {
       notes = entry.getOtherLanguageNotes();
       if (notes.contains("[AUTOTRANSLATED]") || (showUnsupportedFeatures && !notes.equals(""))) {
+        // In showUnsupportedFeatures mode, if the notes are suppressed, display a message so it's
+        // clear that this is what's happened (i.e., not just that the non-English notes were
+        // empty because they have not been translated), since the English notes will be displayed
+        // in this mode.
+        if (notes.equals("-")) {
+          notes = "[English notes will not be shown in other language]";
+        }
         // If notes are autotranslated, or unsupported features are enabled, display original
         // English notes also.
         notes += "\n\n" + entry.getNotes();
+      } else if (notes.equals("-")) {
+        // If the non-English notes is just the string "-", this indicates that the display of
+        // notes should be suppressed. 
+        notes = "";
       }
     } else {
       notes = entry.getNotes();

--- a/app/src/main/java/org/tlhInganHol/android/klingonassistant/KlingonContentProvider.java
+++ b/app/src/main/java/org/tlhInganHol/android/klingonassistant/KlingonContentProvider.java
@@ -1205,7 +1205,10 @@ public class KlingonContentProvider extends ContentProvider {
       }
     }
 
-    // Returns true iff the other-language notes should be displayed.
+    // Returns true iff the other-language notes should be displayed. Note that the other-language
+    // notes can be set to the string "-" (meaning the other-language notes are empty, but these
+    // empty notes override the English notes), in which case this function will still return true.
+    // It's up to the caller to "display" these empty notes (i.e., suppress the English notes).
     public boolean shouldDisplayOtherLanguageNotes() {
       SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(mContext);
       final String otherLang =


### PR DESCRIPTION
This can be done by setting the notes to "-".

(This is needed since if the non-English notes are the empty string, the English notes would be displayed.)