### PR TITLE
Ignore unrecognised part of speech metadata tags.

### DIFF
--- a/app/src/main/java/org/tlhInganHol/android/klingonassistant/KlingonContentDatabase.java
+++ b/app/src/main/java/org/tlhInganHol/android/klingonassistant/KlingonContentDatabase.java
@@ -209,7 +209,7 @@ public class KlingonContentDatabase {
   // the IDs of the first entry and one past the ID of the last non-hypothetical,
   // non-extended-canon entry in the database, respectively.
   private static final int ID_OF_FIRST_ENTRY = 10000;
-  private static final int ID_OF_FIRST_EXTRA_ENTRY = 15112;
+  private static final int ID_OF_FIRST_EXTRA_ENTRY = 15109;
 
   private final KlingonDatabaseOpenHelper mDatabaseOpenHelper;
   private static final HashMap<String, String> mColumnMap = buildColumnMap();

--- a/app/src/main/java/org/tlhInganHol/android/klingonassistant/KlingonContentProvider.java
+++ b/app/src/main/java/org/tlhInganHol/android/klingonassistant/KlingonContentProvider.java
@@ -846,8 +846,7 @@ public class KlingonContentProvider extends ContentProvider {
 
           // No match to attributes.
         } else {
-          // Log error if part of speech could not be determined.
-          Log.e(TAG, "{" + mEntryName + "} has unrecognised attribute: \"" + attr + "\"");
+          Log.d(TAG, "{" + mEntryName + "} has unrecognised attribute: \"" + attr + "\"");
         }
       }
     }


### PR DESCRIPTION
No point in having to update the app every time we add a new one.